### PR TITLE
Update Usage with -w and -b

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Currently supports CDF, CDA and CDE and pentaho 3.6 to 3.8
 
 Requirements: Linux, macintosh or windows with cygwin, wget, unzip
 
-Usage: ctools-installer.sh <path-to-pentaho-solutions>
+Usage: ctools-installer.sh -s solutionPath [-w pentahoWebapPath] [-b branch]
 
 Please backup your solution, we're not resposible by any harm this does to your server.
 

--- a/ctools-installer.sh
+++ b/ctools-installer.sh
@@ -38,7 +38,7 @@ echo
 usage (){
 
 	echo 
-	echo Usage: ctools-installer.sh -s solutionPath -w pentahoWebapPath -b branch
+	echo "Usage: ctools-installer.sh -s solutionPath [-w pentahoWebapPath] [-b branch]"
 	echo
 	echo "-s    Solution path (eg: /biserver/pentaho-solutions)"
 	echo "-w    Pentaho webapp server path (requiresd for cgg, eg: /biserver-ce/tomcat/webapps/pentaho)"


### PR DESCRIPTION
Update README with -w and -b arguments to set pentaho webapp path and
branch.

Update Usage message from the script to show -w and -b arguments as
optional.
