### PR TITLE
Dependency checks + unattended update

### DIFF
--- a/ctools-installer.sh
+++ b/ctools-installer.sh
@@ -169,7 +169,7 @@ if ! diff $0 .tmp/ctools-installer.sh >/dev/null ; then
   fi
 
   case $answer in
-	 [Yy]* ) cp .tmp/ctools-installer.sh $0; echo "Upgrade successfull. Rerunning..."; echo "attempting to run '$0 $ORIGINAL_CMDS'"; /bin/bash $0 $ORIGINAL_CMDS; exit 0;;
+	 [Yy]* ) cp .tmp/ctools-installer.sh $0; echo "Upgrade successful. Rerunning command '$0 $ORIGINAL_CMDS'"; /bin/bash $0 $ORIGINAL_CMDS; exit 0;;
   esac
 
 fi


### PR DESCRIPTION
Added checks to make sure "wget" and "unzip" exist, and changed the update logic to obey the "-y" flag.  It also re-runs itself if you choose to upgrade ctools-installer.sh so that it can be run by a script (or just not require the user to pay attention).
