### PR TITLE
Update ctools-installer.sh

### DIFF
--- a/ctools-installer.sh
+++ b/ctools-installer.sh
@@ -254,7 +254,7 @@ downloadMarketplace () {
 	fi
 	download_file "Marketplace"  "$URL"  "plugin.zip"  ".tmp/marketplace"
 	rm -f .tmp/dist/marketplace.xml
-	unzip -o .tmp/marketplace/plugin.zip -d .tmp > /dev/null
+	unzip -o .tmp/marketplace/dist/plugin.zip -d .tmp > /dev/null
 	chmod -R u+rwx .tmp
 	echo "Done"
 }
@@ -278,7 +278,7 @@ downloadCDF () {
 	fi
 	download_file "CDF"  "$URL"  "dist.zip"  ".tmp/cdf"
 	rm -f .tmp/dist/marketplace.xml
-	unzip -o .tmp/cdf/dist.zip -d .tmp > /dev/null
+	unzip -o .tmp/cdf/dist/dist.zip -d .tmp > /dev/null
 	chmod -R u+rwx .tmp
 	echo "Done"
 }
@@ -304,7 +304,7 @@ downloadCDA (){
 	fi
 	download_file "CDA"  "$URL"  "dist.zip"  ".tmp/cda"
 	rm -f .tmp/dist/marketplace.xml
-	unzip -o .tmp/cda/dist.zip  -d .tmp > /dev/null
+	unzip -o .tmp/cda/dist/dist.zip  -d .tmp > /dev/null
 	chmod -R u+rwx .tmp
 	echo "Done"
 }
@@ -328,7 +328,7 @@ downloadCDE (){
 	fi
 	download_file "CDE"  "$URL"  "dist.zip"  ".tmp/cde"
 	rm -f .tmp/dist/marketplace.xml
-	unzip -o .tmp/cde/dist.zip -d .tmp > /dev/null
+	unzip -o .tmp/cde/dist/dist.zip -d .tmp > /dev/null
 	chmod -R u+rwx .tmp
 	echo "Done"
 }
@@ -352,7 +352,7 @@ downloadCGG (){
 	fi
 	download_file "CGG" "$URL" "dist.zip" ".tmp/cgg"
 	rm -f .tmp/dist/marketplace.xml
-	unzip -o .tmp/cgg/dist.zip -d .tmp > /dev/null
+	unzip -o .tmp/cgg/dist/dist.zip -d .tmp > /dev/null
 	chmod -R u+rwx .tmp
 	echo "Done"
 }
@@ -366,7 +366,7 @@ downloadCFR (){
 	fi
 	download_file "CFR" "$URL" "dist.zip" ".tmp/cfr"
 	rm -f .tmp/dist/marketplace.xml
-	unzip -o .tmp/cfr/dist.zip -d .tmp > /dev/null
+	unzip -o .tmp/cfr/dist/dist.zip -d .tmp > /dev/null
 	chmod -R u+rwx .tmp
 	echo "Done"
 }
@@ -380,7 +380,7 @@ downloadSparkl (){
 	fi
 	download_file "Sparkl" "$URL" "dist.zip" ".tmp/sparkl"
 	rm -f .tmp/dist/marketplace.xml
-	unzip -o .tmp/sparkl/dist.zip -d .tmp > /dev/null
+	unzip -o .tmp/sparkl/dist/dist.zip -d .tmp > /dev/null
 	chmod -R u+rwx .tmp
 	echo "Done"
 }
@@ -390,7 +390,7 @@ downloadCDC (){
 	URL='http://ci.analytical-labs.com/job/Webdetails-CDC'$URL1'/lastSuccessfulBuild/artifact/dist/*zip*/dist.zip'
 	download_file "CDC" "$URL" "dist.zip" ".tmp/cdc"
 	rm -f .tmp/dist/marketplace.xml
-	unzip -o .tmp/cdc/dist.zip -d .tmp > /dev/null
+	unzip -o .tmp/cdc/dist/dist.zip -d .tmp > /dev/null
 	chmod -R u+rwx .tmp
 	echo "Done"
 }
@@ -400,7 +400,7 @@ downloadCDB (){
 	URL='http://ci.analytical-labs.com/job/Webdetails-CDB'$URL1'/lastSuccessfulBuild/artifact/dist/*zip*/dist.zip'
 	download_file "CDB" "$URL" "dist.zip" ".tmp/cdb"
 	rm -f .tmp/dist/marketplace.xml
-	unzip -o .tmp/cdb/dist.zip -d .tmp > /dev/null
+	unzip -o .tmp/cdb/dist/dist.zip -d .tmp > /dev/null
 	chmod -R u+rwx .tmp
 	echo "Done"
 }
@@ -419,7 +419,7 @@ downloadCDV (){
 	fi
 	download_file "CDV" "$URL" "dist.zip" ".tmp/cdv"
 	rm -f .tmp/dist/marketplace.xml
-	unzip -o .tmp/cdv/dist.zip -d .tmp > /dev/null
+	unzip -o .tmp/cdv/dist/dist.zip -d .tmp > /dev/null
 	chmod -R u+rwx .tmp
 	echo "Done"
 }
@@ -432,7 +432,7 @@ downloadSaiku (){
 			URL='http://ci.analytical-labs.com/job/saiku-bi-platform-plugin/lastSuccessfulBuild/artifact/saiku-bi-platform-plugin/target/*zip*/target.zip'
 			download_file "SAIKU" "$URL" "target.zip" ".tmp/saiku"
 			rm -f .tmp/dist/marketplace.xml
-			unzip -o .tmp/saiku/target.zip -d .tmp > /dev/null
+			unzip -o .tmp/saiku/dist/target.zip -d .tmp > /dev/null
 			chmod -R u+rwx .tmp
 			mv .tmp/target/saiku-* .tmp
 		else
@@ -445,7 +445,7 @@ downloadSaiku (){
 			URL='http://ci.analytical-labs.com/job/saiku-bi-platform-plugin-p5/lastSuccessfulBuild/artifact/saiku-bi-platform-plugin-p5/target/*zip*/target.zip'
 			download_file "SAIKU" "$URL" "target.zip" ".tmp/saiku"
 			rm -f .tmp/dist/marketplace.xml
-			unzip -o .tmp/saiku/target.zip -d .tmp > /dev/null
+			unzip -o .tmp/saiku/dist/target.zip -d .tmp > /dev/null
 			chmod -R u+rwx .tmp
 			mv .tmp/target/saiku-* .tmp
 		else
@@ -463,7 +463,7 @@ downloadSaikuAdhoc (){
 		URL='http://ci.analytical-labs.com/job/saiku-adhoc-plugin/lastSuccessfulBuild/artifact/saiku-adhoc-plugin/target/*zip*/target.zip'
 		download_file "SAIKU_ADHOC" "$URL" "target.zip" ".tmp/saiku-adhoc"
 		rm -f .tmp/dist/marketplace.xml
-		unzip -o .tmp/saiku-adhoc/target.zip -d .tmp > /dev/null
+		unzip -o .tmp/saiku-adhoc/dist/target.zip -d .tmp > /dev/null
 		chmod -R u+rwx .tmp
 		mv .tmp/target/saiku-adhoc-* .tmp
 	else


### PR DESCRIPTION
when ctools-installer attempted to download and install the packages, all of the root zip files were stored in a ".tmp/<package>/dist/" folder.  When I first attempted to run the script, it returned errors "no zip found".  When I changed that folder to include the /dist portion, the installation worked.
