### PR TITLE
Update CDF for Pentaho 5x to use the latest stable build.

### DIFF
--- a/ctools-installer.sh
+++ b/ctools-installer.sh
@@ -273,7 +273,7 @@ downloadCDF () {
 	    then
 		    URL='http://ci.pentaho.com/job/pentaho-cdf/lastSuccessfulBuild/artifact/cdf-pentaho5/dist/*zip*/dist.zip'
 		else
-            URL='http://ci.analytical-labs.com/job/Webdetails-CDF-5-Release/2/artifact/bi-platform-v2-plugin/dist/*zip*/dist.zip'
+            URL='http://ci.analytical-labs.com/job/Webdetails-CDF-5-Release/lastSuccessfulBuild/artifact/bi-platform-v2-plugin/dist/*zip*/dist.zip'
 		fi
 	fi
 	download_file "CDF"  "$URL"  "dist.zip"  ".tmp/cdf"
@@ -903,7 +903,7 @@ echo
 
 
 
-#cleanup
+cleanup
 
 echo
 echo Done!


### PR DESCRIPTION
Update CDF for Pentaho 5x to use the latest stable build.
Re-enabled cleanup() an the end of the script.
