### PR TITLE
Handle filenames for minor release versions, eg, 14.12.10.1

### DIFF
--- a/ctools-installer.sh
+++ b/ctools-installer.sh
@@ -193,7 +193,8 @@ do
   fi
 done
 
-
+# enable extended regexp matching
+shopt -s extglob
 
 if [ $BRANCH = 'dev' ]
 then
@@ -201,7 +202,8 @@ then
     FILESUFIX='-TRUNK-SNAPSHOT'
 else
 	URL1='-release'
-    FILESUFIX='-??.??.??'
+    FILESUFIX='-+([0-9.])' # +([0-9.]) is an extended regexp. meaning match
+                           # at least one of these items: [0-9.]
 fi
 
 


### PR DESCRIPTION
This change supports the latest stable release, 14.12.10.1
